### PR TITLE
Add pkg-config and libcmocka-dev to dependencies

### DIFF
--- a/install.html
+++ b/install.html
@@ -193,7 +193,8 @@ make install</code></pre>
             <pre><code>automake
 autoconf
 autoconf-archive
-libtool</code></pre>
+libtool
+pkg-config</code></pre>
 
             <h4>Required dependencies:</h4>
 
@@ -202,6 +203,7 @@ libtool</code></pre>
             <p>Profanity also requires:</p>
             <pre><code>libncursesw5-dev
 libglib2.0-dev
+libcmocka-dev
 libcurl3-dev
 libreadline-dev</code></pre>
 


### PR DESCRIPTION
`pkg-config` is a required build-tool. `libcmocka-dev` is used in a test, thus a required dependency.