### PR TITLE
add NixOS package

### DIFF
--- a/install.html
+++ b/install.html
@@ -92,6 +92,13 @@
                         <a href="http://packages.ubuntu.com/search?keywords=profanity&searchon=names&suite=all&section=all" target="_blank">packages.ubuntu.org</a>
                     </td>
                 </tr>
+                <tr>
+                    <td>Nix/NixOS</td>
+                    <td>
+                        <a href="https://nixos.org/nixos/packages.html#profanity" target="_blank">nixos.org/nixos/packages.html</a><br>
+                        <a href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/instant-messengers/profanity/default.nix" target="_blank">github.com/NixOS/nixpkgs/</a>
+                    </td>
+                </tr>
             </table>
             <table>
                 <tr>


### PR DESCRIPTION
`Nix`, the functional package manager supports `profanity`. This adds a hint to the website.

If you have `Nix` installed, you can spawn a temporal shell with `profanity` available with 

```nix-shell -p profanity```

.
